### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/evoln/trimevrccfiles.py
+++ b/evoln/trimevrccfiles.py
@@ -9,7 +9,7 @@ evnmodend = []
 print "file".rjust(10), "start".rjust(10), "end".rjust(10)
 
 for n in range(0,100):
-    filename = "ev%03d.dat" % n
+    filename = "ev{0:03d}.dat".format(n)
     if os.path.isfile(filename):
         modelNumbers = []
         with open(filename, mode='rb') as evfile:
@@ -27,17 +27,17 @@ for n in range(0,100):
 
 for n in range(1,len(evfilenum)):
     if evnmodstart[n] <= evnmodstart[n-1]:
-        print "WARNING: ev%03d.dat starts before ev%03d.dat!" % (evfilenum[n],evfilenum[n-1])
+        print "WARNING: ev{0:03d}.dat starts before ev{1:03d}.dat!".format(evfilenum[n], evfilenum[n-1])
     elif evnmodend[n-1] >= evnmodstart[n]:
-        print "ev%03d.dat overlaps with ev%03d.dat" % (evfilenum[n-1],evfilenum[n])
-        if os.path.isfile("ev%03dtrim.dat" % evfilenum[n-1]):
-            print "- deleting existing file ev%03dtrim.dat" % evfilenum[n-1]
-            os.system("rm ev%03dtrim.dat" % evfilenum[n-1])
-        print "- trimming ev%03d.dat to end at %d" % (evfilenum[n-1],evnmodstart[n]-1)
-        os.system("echo 'ev%03d.dat\nev%03dtrim.dat\n0\n" % (evfilenum[n-1],evfilenum[n-1]) + str(evnmodstart[n]-1) + "' | selectp > /dev/null")
+        print "ev{0:03d}.dat overlaps with ev{1:03d}.dat".format(evfilenum[n-1], evfilenum[n])
+        if os.path.isfile("ev{0:03d}trim.dat".format(evfilenum[n-1])):
+            print "- deleting existing file ev{0:03d}trim.dat".format(evfilenum[n-1])
+            os.system("rm ev{0:03d}trim.dat".format(evfilenum[n-1]))
+        print "- trimming ev{0:03d}.dat to end at {1:d}".format(evfilenum[n-1], evnmodstart[n]-1)
+        os.system("echo 'ev{0:03d}.dat\nev{1:03d}trim.dat\n0\n".format(evfilenum[n-1], evfilenum[n-1]) + str(evnmodstart[n]-1) + "' | selectp > /dev/null")
 
-        if os.path.isfile("rcc%03dtrim.dat" % evfilenum[n-1]):
-            print "- deleting existing file rcc%03dtrim.dat" % evfilenum[n-1]
-            os.system("rm rcc%03dtrim.dat" % evfilenum[n-1])
-        print "- trimming rcc%03d.dat to end at %d" % (evfilenum[n-1],evnmodstart[n]-1)
-        os.system("echo 'rcc%03d.dat\nrcc%03dtrim.dat\n0\n" % (evfilenum[n-1],evfilenum[n-1]) + str(evnmodstart[n]-1) + "' | rccselect > /dev/null")
+        if os.path.isfile("rcc{0:03d}trim.dat".format(evfilenum[n-1])):
+            print "- deleting existing file rcc{0:03d}trim.dat".format(evfilenum[n-1])
+            os.system("rm rcc{0:03d}trim.dat".format(evfilenum[n-1]))
+        print "- trimming rcc{0:03d}.dat to end at {1:d}".format(evfilenum[n-1], evnmodstart[n]-1)
+        os.system("echo 'rcc{0:03d}.dat\nrcc{1:03d}trim.dat\n0\n".format(evfilenum[n-1], evfilenum[n-1]) + str(evnmodstart[n]-1) + "' | rccselect > /dev/null")

--- a/getmodelabundances.py
+++ b/getmodelabundances.py
@@ -112,12 +112,12 @@ if not args.noheader:
     print "# model number:", modelNumber
     print "# number of mass points:", numMassPoints
     print "# comp file species count:", compNumSpecies
-    print "# convective boundaries: " + ",".join(map(lambda x:'%.5f' % x,convectiveBoundaries))
+    print "# convective boundaries: " + ",".join(map(lambda x:'{0:.5f}'.format(x),convectiveBoundaries))
     print "# values are log10(Y)"
     print formatRow(["#mass"]+map(lambda x:speciesList[x][2],speciesDisplayedNumbers))
 
 for massPointNum in range(numMassPoints):
     if args.mass == None or massPoints[massPointNum] >= float(args.mass):
-        print formatRow(["%.5f" % massPoints[massPointNum]] + map(lambda z: ("-inf" if z <= 0 else '%.3f' % math.log10(z)),abundances[massPointNum]))
+        print formatRow(["{0:.5f}".format(massPoints[massPointNum])] + map(lambda z: ("-inf" if z <= 0 else '{0:.3f}'.format(math.log10(z))),abundances[massPointNum]))
         if args.mass != None:
             break

--- a/getmodelabundances.py
+++ b/getmodelabundances.py
@@ -112,12 +112,13 @@ if not args.noheader:
     print "# model number:", modelNumber
     print "# number of mass points:", numMassPoints
     print "# comp file species count:", compNumSpecies
-    print "# convective boundaries: " + ",".join(map(lambda x:'{0:.5f}'.format(x),convectiveBoundaries))
+    print "# convective boundaries: " + ",".join(map('{0:.5f}'.format,convectiveBoundaries))
     print "# values are log10(Y)"
-    print formatRow(["#mass"]+map(lambda x:speciesList[x][2],speciesDisplayedNumbers))
+    print formatRow(["#mass"] + map(lambda x:speciesList[x][2],speciesDisplayedNumbers))
 
 for massPointNum in range(numMassPoints):
     if args.mass == None or massPoints[massPointNum] >= float(args.mass):
-        print formatRow(["{0:.5f}".format(massPoints[massPointNum])] + map(lambda z: ("-inf" if z <= 0 else '{0:.3f}'.format(math.log10(z))),abundances[massPointNum]))
+        print formatRow(["{0:.5f}".format(massPoints[massPointNum])] + map(
+            lambda z: ("-inf" if z <= 0 else '{0:.3f}'.format(math.log10(z))),abundances[massPointNum]))
         if args.mass != None:
             break

--- a/getsurfabunds.py
+++ b/getsurfabunds.py
@@ -15,10 +15,10 @@ for modeldir in modellist:
         outrow = ["!"] * len(outelements)
         for row in csvReader:
             if row[0] in outelements:
-                outrow[outelements.index(row[0])] = ("%0.3f" % float(row[2])).ljust(5)
+                outrow[outelements.index(row[0])] = ("{0:0.3f}".format(float(row[2]))).ljust(5)
             if row[0:2] == ["#","C/O"]:
-                outrow.append("%0.3f" % float(row[3][:-1])) #C/O
-                outrow.append("%0.3f" % float(row[6][:-1])) #c12/c13
+                outrow.append("{0:0.3f}".format(float(row[3][:-1]))) #C/O
+                outrow.append("{0:0.3f}".format(float(row[6][:-1]))) #c12/c13
                 #if row[0:2] == ["#","mg24/mg25"]:
                 #outrow.append("%0.3f  " % float(row[3][:-1])) #mg24/mg25
                     #outrow.append("%0.3f" % float(row[6])) #mg24/mg26

--- a/plotcomp.py
+++ b/plotcomp.py
@@ -104,7 +104,7 @@ for compfilename in compfilelist:
     print "# model number:", modelNumber
     print "# number of mass points:", numMassPoints
     print "# comp file species count:", compNumSpecies
-    print "# convective boundaries: [" + "][".join(['%.5f, %.5f' % (cvz[0],cvz[1]) for cvz in convectiveBoundaries]) + "]"
+    print "# convective boundaries: [" + "][".join(['{0:.5f}, {1:.5f}'.format(cvz[0], cvz[1]) for cvz in convectiveBoundaries]) + "]"
     #print "# values are mass fraction"
     #print ",".join(["#mass"]+map(lambda x:speciesList[x][2],speciesDisplayedNumbers))
 

--- a/plotcomp.py
+++ b/plotcomp.py
@@ -53,7 +53,7 @@ for (dirpath, dirnames, filenames) in walk(modelfolder + "comp/"):
 for compfilename in compfilelist:
     if isBinaryFile(dirpath + compfilename):
         print "\n==>comp file (bin): '" + compfilename
-        with open(dirpath + compfile, mode='rb') as fcomp:
+        with open(dirpath + compfilename, mode='rb') as fcomp:
             fileContent = fcomp.read()
             #model number is wrong for some reason
             modelNumber = struct.unpack("<H", fileContent[0:2])[0]
@@ -94,12 +94,13 @@ for compfilename in compfilelist:
         for massPointNum in range(numMassPoints):
             for s in range(len(speciesDisplayedNumbers)):
                 massnumber = speciesList[speciesDisplayedNumbers[s]][0]
-                abundances[massPointNum][s] = (massnumber * 0.5 * (float(compRaw[3 + numMassPoints + massPointNum*compNumSpecies + speciesDisplayedNumbers[s]]) + float(compRaw[3 + numMassPoints + (numMassPoints + massPointNum)*compNumSpecies + speciesDisplayedNumbers[s]])))
+                abundances[massPointNum][s] = (massnumber * 0.5 * (float(compRaw[3 + numMassPoints + massPointNum*compNumSpecies + speciesDisplayedNumbers[s]])
+                                               + float(compRaw[3 + numMassPoints + (numMassPoints + massPointNum)*compNumSpecies + speciesDisplayedNumbers[s]])))
         numConvectiveBoundaries = int(compRaw[3 + numMassPoints + numMassPoints*compNumSpecies*2])
         convectiveBoundaries = map(float,compRaw[3 + numMassPoints + numMassPoints*compNumSpecies*2+1:][:numConvectiveBoundaries])
         convectiveBoundaries = zip(convectiveBoundaries[0::2], convectiveBoundaries[1::2])
 
-    modelNumber = int(compfile[-11:-4]) #overwrite value from the file with number from filename
+    modelNumber = int(compfilename[-11:-4]) #overwrite value from the file with number from filename
 
     print "# model number:", modelNumber
     print "# number of mass points:", numMassPoints
@@ -127,7 +128,7 @@ for compfilename in compfilelist:
     plt.setp(plt.getp(ax, 'yticklabels'), fontsize=fs-2)
     ax.set_ylabel('Mass fraction', labelpad=12, fontsize=fs)
     ax.set_xlabel("M / M$_\odot$", labelpad=12, fontsize=fs)
-    outfile = 'm6y35comp/pdf/' + compfile + '.pdf'
+    outfile = 'm6y35comp/pdf/' + compfilename + '.pdf'
     print "writing " + outfile
     fig.savefig(outfile,format='pdf')
     plt.close()

--- a/plotcompmap.py
+++ b/plotcompmap.py
@@ -120,7 +120,7 @@ for compfilename in compfilelist:
     print "# model number:", modelNumber
     print "# number of mass points:", numMassPoints
     print "# comp file species count:", compNumSpecies
-    print "# convective boundaries: [" + "][".join(['%.5f, %.5f' % (cvz[0],cvz[1]) for cvz in convectiveBoundaries]) + "]"
+    print "# convective boundaries: [" + "][".join(['{0:.5f}, {1:.5f}'.format(cvz[0], cvz[1]) for cvz in convectiveBoundaries]) + "]"
     #print "# values are mass fraction"
     #print ",".join(["#mass"]+map(lambda x:speciesList[x][2],speciesDisplayedNumbers))
 

--- a/plotcompmap.py
+++ b/plotcompmap.py
@@ -41,7 +41,7 @@ with open(speciesfile, 'rb') as txtFile:
         speciesList[i] = (int(row[0]), row[1], row[2], int(row[3]))
 
 #convert species names to numbers
-speciesDisplayedNumbers = map(lambda z: speciesList.index(z), filter(lambda z: z[2] in speciesNamesDisplayed, speciesList))
+speciesDisplayedNumbers = map(speciesList.index, filter(lambda z: z[2] in speciesNamesDisplayed, speciesList))
 
 fig = plt.figure(figsize=(12,7))
 ax = fig.add_axes([0.10, 0.00, 0.85, 0.97])
@@ -85,7 +85,8 @@ for compfilename in compfilelist:
                     abundIndex2 = 6 + 4 * (numMassPoints + compNumSpecies * (numMassPoints + massPointNum) + speciesDisplayedNumbers[s])
                     massnumber = speciesList[speciesDisplayedNumbers[s]][0]
                     #average up and down flows and multiply by mass number to get mass fraction
-                    abundances[massPointNum][s] = (massnumber * 0.5 * (struct.unpack("<f", fileContent[abundIndex:abundIndex+4])[0] + struct.unpack("f", fileContent[abundIndex2:abundIndex2+4])[0]))
+                    abundances[massPointNum][s] = (massnumber * 0.5 * (struct.unpack("<f", fileContent[abundIndex:abundIndex+4])[0]
+                                                   + struct.unpack("f", fileContent[abundIndex2:abundIndex2+4])[0]))
 
             convindex = 6 + 4 * (numMassPoints + numMassPoints*compNumSpecies*2)
             numConvectiveBoundaries = struct.unpack("H", fileContent[convindex:convindex+2])[0]
@@ -110,7 +111,8 @@ for compfilename in compfilelist:
         for massPointNum in range(numMassPoints):
             for s in range(len(speciesDisplayedNumbers)):
                 massnumber = speciesList[speciesDisplayedNumbers[s]][0]
-                abundances[massPointNum][s] = (massnumber * 0.5 * (float(compRaw[3 + numMassPoints + massPointNum*compNumSpecies + speciesDisplayedNumbers[s]]) + float(compRaw[3 + numMassPoints + (numMassPoints + massPointNum)*compNumSpecies + speciesDisplayedNumbers[s]])))
+                abundances[massPointNum][s] = (massnumber * 0.5 * (float(compRaw[3 + numMassPoints + massPointNum*compNumSpecies + speciesDisplayedNumbers[s]])
+                                               + float(compRaw[3 + numMassPoints + (numMassPoints + massPointNum)*compNumSpecies + speciesDisplayedNumbers[s]])))
         numConvectiveBoundaries = int(compRaw[3 + numMassPoints + numMassPoints*compNumSpecies*2])
         convectiveBoundaries = map(float,compRaw[3 + numMassPoints + numMassPoints*compNumSpecies*2+1:][:numConvectiveBoundaries])
         convectiveBoundaries = zip(convectiveBoundaries[0::2], convectiveBoundaries[1::2])
@@ -208,7 +210,8 @@ startindex = -1
 for i in range(len(iscvnzonenmod)):
     if (iscvnzoneinner[i] == 0.0 and iscvnzoneouter[i] == 0.0): #or i == len(iscvnzonenmod)-1:
         if startindex != -1:
-            plt.fill_between(iscvnzonenmod[startindex:i], iscvnzoneinner[startindex:i], iscvnzoneouter[startindex:i], facecolor=(55.0/255,101.0/255,186.0/255), lw=0)
+            plt.fill_between(iscvnzonenmod[startindex:i], iscvnzoneinner[startindex:i],
+                             iscvnzoneouter[startindex:i], facecolor=(55.0/255,101.0/255,186.0/255), lw=0)
             startindex = -1
     else:
         if startindex == -1:

--- a/plotev.py
+++ b/plotev.py
@@ -6,7 +6,7 @@ import argparse
 def evcode(string):
     value = int(string)
     if value < 1 or value > 64:
-        msg = "%r is not between 1 and 64." % string
+        msg = "{0!r} is not between 1 and 64.".format(string)
         raise argparse.ArgumentTypeError(msg)
     return value
 

--- a/plotfinalcorecompremote.py
+++ b/plotfinalcorecompremote.py
@@ -79,12 +79,12 @@ for mass in ['3','4','5','6']:
                 for species in specieslist:
                     abundances[species] = []
 
-        print('/'.join(bobfilename.split('/')[-2:]) + ': last NMOD=%7d, Mtot=%.3f, Mcore=%.3f' % (modelnumber, mtot, mcore[m]))
+        print('/'.join(bobfilename.split('/')[-2:]) + ': last NMOD={0:7d}, Mtot={1:.3f}, Mcore={2:.3f}'.format(modelnumber, mtot, mcore[m]))
         #print massgrid
         for (species,color,dashes) in zip(specieslist,abundancecolorlist,abundancedasheslist):
             ax.plot(massgrid, abundances[species], label=species, color=color, dashes=dashes, lw=2, marker='None', markersize=8, markeredgewidth=0)
-	print('Central C/N=%.3f' % (abundances['C'][-1]/abundances['N'][-1] * 14.0/12.0))
-        print('Central C/O=%.3f' % (abundances['C'][-1]/abundances['O'][-1] * 16.0/12.0))
+	print('Central C/N={0:.3f}'.format((abundances['C'][-1]/abundances['N'][-1] * 14.0/12.0)))
+        print('Central C/O={0:.3f}'.format((abundances['C'][-1]/abundances['O'][-1] * 16.0/12.0)))
 	print(' ')
         ax.set_xlim(xmax=max(mcore)*1.05)
         modellabel = modellist[m][1:].split('z')[0] + ' M$_\odot$, Y=0.' + modellist[m][-2:]

--- a/readpulseljs.py
+++ b/readpulseljs.py
@@ -70,15 +70,15 @@ stdevInterpulsePeriod = math.sqrt(reduce(lambda x, y: x + y, map(lambda z: (z-av
 
 avgIscvnTime = reduce(lambda x, y: x + y, ListIscvnTime) / len(ListIscvnTime)
 stdevIscvnTime = math.sqrt(reduce(lambda x, y: x + y, map(lambda z: (z-avgIscvnTime)**2, ListIscvnTime)) / len(ListIscvnTime))
-print "Pulses with Tbce>50 MK: %d" % HBBpulsecount + " out of %d" % pulseCount
-print "Mcore at 1st TP: %.3f" % float(tpdata[1]['Mcore'])
-print "Total mass dredged up: %.5e" % totalMDU
-print "Max lambda: %.2f" % MaxLambda
-print "Max THeshell: %.2e" % MaxTHeShell
-print "Max THshell: %.2e" % MaxTHShell
-print "Max Mpdcz: %.4f" % MaxMHecsh
-print "Max Tbce: %.2e" % MaxTbce
-print "Avg interpulse period: %.2f +/- %.2f yrs" % (avgInterpulsePeriod, stdevInterpulsePeriod)
-print "Avg iscvn time: %.2f +/- %.2f yrs" % (avgIscvnTime, stdevIscvnTime)
-print "Avg Teff: %d" % (TeffSum/TeffValCount)
+print "Pulses with Tbce>50 MK: {0:d}".format(HBBpulsecount) + " out of {0:d}".format(pulseCount)
+print "Mcore at 1st TP: {0:.3f}".format(float(tpdata[1]['Mcore']))
+print "Total mass dredged up: {0:.5e}".format(totalMDU)
+print "Max lambda: {0:.2f}".format(MaxLambda)
+print "Max THeshell: {0:.2e}".format(MaxTHeShell)
+print "Max THshell: {0:.2e}".format(MaxTHShell)
+print "Max Mpdcz: {0:.4f}".format(MaxMHecsh)
+print "Max Tbce: {0:.2e}".format(MaxTbce)
+print "Avg interpulse period: {0:.2f} +/- {1:.2f} yrs".format(avgInterpulsePeriod, stdevInterpulsePeriod)
+print "Avg iscvn time: {0:.2f} +/- {1:.2f} yrs".format(avgIscvnTime, stdevIscvnTime)
+print "Avg Teff: {0:d}".format((TeffSum/TeffValCount))
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:lukeshingles:msssp-ppns-tools?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:lukeshingles:msssp-ppns-tools?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
